### PR TITLE
fix(links): добавить noopener к атрибутам rel (P0.1)

### DIFF
--- a/src/components/decoration/winter/toast.tsx
+++ b/src/components/decoration/winter/toast.tsx
@@ -65,7 +65,7 @@ export function NewYearToast() {
                                         <a
                                             href={NAVIGATION_LINKS.TELEGRAM_AUTHOR}
                                             target="_blank"
-                                            rel="noreferrer"
+                                            rel="noopener noreferrer"
                                         >
                                             Павел Елисеев
                                         </a>

--- a/src/components/sections/preview/pdf-viewer.tsx
+++ b/src/components/sections/preview/pdf-viewer.tsx
@@ -352,6 +352,7 @@ export default function PdfViewer({
             <Link
               href={pdfUrl}
               target="_blank"
+              rel="noopener noreferrer"
               onClick={(e) => e.stopPropagation()}
             >
               <Button


### PR DESCRIPTION
## Что изменилось
- `src/components/decoration/winter/toast.tsx`: `rel="noreferrer"` → `rel="noopener noreferrer"` (отсутствовал `noopener`)
- `src/components/sections/preview/pdf-viewer.tsx`: добавлен `rel="noopener noreferrer"` на ссылку скачивания (полностью отсутствовал)

## Проверка
- [ ] `grep -rn 'rel="noreferrer"' src/ --include="*.tsx"` возвращает пустой результат
- [ ] Все внешние ссылки имеют корректные атрибуты

Closes #45