### PR TITLE
feat(seo): добавить sitemap, robots.txt, WebSite JSON-LD, страницу /authors (P1.4)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,20 @@ module.exports = {
         pathname: "/typst-gost/examples/**",
         search: "",
       },
+      // Для аватарок authors
+      {
+        protocol: "https",
+        hostname: "github.com",
+        port: "",
+        pathname: "/*.png",
+        search: "",
+      },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+        port: "",
+        pathname: "/u/*",
+      }
     ],
   },
   turbopack: {},

--- a/src/app/authors/data.tsx
+++ b/src/app/authors/data.tsx
@@ -7,7 +7,8 @@ export interface Author {
   name: string
   role: string
   github: string
-  telegram: string | null
+  telegram?: string
+  website?: string
   avatarPath?: string
   isInactive?: boolean
   tags: AuthorTag[]
@@ -43,7 +44,7 @@ export const authors: Author[] = [
     name: "benzlokzik",
     role: "Разработчик",
     github: "https://github.com/benzlokzik",
-    telegram: "https://t.me/benzlokzik",
+    website: "https://epops.space",
     avatarPath: "https://github.com/benzlokzik.png",
     tags: [TAGS.website, TAGS.infrastructure, TAGS.template],
   },

--- a/src/app/authors/data.tsx
+++ b/src/app/authors/data.tsx
@@ -23,6 +23,12 @@ export const TAGS = {
   infrastructure: { label: "Инфраструктура", className: "bg-cyan-500/10 text-cyan-400 border-cyan-500/20" },
 } as const
 
+export const EXCLUDED_CONTRIBUTOR_LOGINS = [
+  "dependabot",
+  "actions-user",
+  "claude",
+] as const
+
 export const authors: Author[] = [
   {
     name: "Forgenet",
@@ -37,7 +43,7 @@ export const authors: Author[] = [
     name: "benzlokzik",
     role: "Разработчик",
     github: "https://github.com/benzlokzik",
-    telegram: "https://t.me/anri4ok",
+    telegram: "https://t.me/benzlokzik",
     avatarPath: "https://github.com/benzlokzik.png",
     tags: [TAGS.website, TAGS.infrastructure, TAGS.template],
   },

--- a/src/app/authors/data.tsx
+++ b/src/app/authors/data.tsx
@@ -1,0 +1,53 @@
+export interface AuthorTag {
+  label: string
+  className: string
+}
+
+export interface Author {
+  name: string
+  role: string
+  github: string
+  telegram: string | null
+  avatarPath?: string
+  isInactive?: boolean
+  tags: AuthorTag[]
+}
+
+export const TAGS = {
+  template: { label: "Шаблон", className: "bg-amber-500/10 text-amber-400 border-amber-500/20" },
+  website: { label: "Сайт", className: "bg-blue-500/10 text-blue-400 border-blue-500/20" },
+  docs: { label: "Документация", className: "bg-emerald-500/10 text-emerald-400 border-emerald-500/20" },
+  presentation: { label: "Презентация", className: "bg-purple-500/10 text-purple-400 border-purple-500/20" },
+  promo: { label: "Продвижение", className: "bg-pink-500/10 text-pink-400 border-pink-500/20" },
+  design: { label: "Дизайн", className: "bg-rose-500/10 text-rose-400 border-rose-500/20" },
+  infrastructure: { label: "Инфраструктура", className: "bg-cyan-500/10 text-cyan-400 border-cyan-500/20" },
+} as const
+
+export const authors: Author[] = [
+  {
+    name: "Forgenet",
+    role: "Создатель шаблона",
+    github: "https://github.com/F0rgenet",
+    telegram: "https://t.me/forgenet",
+    avatarPath: "https://github.com/F0rgenet.png",
+    isInactive: false,
+    tags: [TAGS.template, TAGS.website, TAGS.docs],
+  },
+  {
+    name: "benzlokzik",
+    role: "Разработчик",
+    github: "https://github.com/benzlokzik",
+    telegram: "https://t.me/anri4ok",
+    avatarPath: "https://github.com/benzlokzik.png",
+    tags: [TAGS.website, TAGS.infrastructure, TAGS.template],
+  },
+  {
+    name: "imCatCatcher",
+    role: "Разработчик",
+    github: "https://github.com/imCatCatcher",
+    telegram: "https://t.me/imcatcatcher",
+    avatarPath: "https://github.com/imCatCatcher.png",
+    isInactive: true,
+    tags: [TAGS.template, TAGS.docs],
+  }
+]

--- a/src/app/authors/page.tsx
+++ b/src/app/authors/page.tsx
@@ -1,0 +1,191 @@
+import { Metadata } from "next"
+import Image from "next/image"
+import { Github, User, ExternalLink } from "lucide-react"
+import { Navbar } from "@/components/sections/navbar"
+import { Footer } from "@/components/sections/footer"
+import { PageBackground } from "@/components/decoration/background"
+import { NAVIGATION_LINKS } from "@/lib/navigation"
+import { cn } from "@/lib/utils"
+import { authors } from "./data"
+
+export const metadata: Metadata = {
+  title: "Об авторах — Typst Gost",
+  description: "Авторы и контрибьюторы экосистемы Typst Gost",
+}
+
+interface GitHubContributor {
+  login: string
+  avatar_url: string
+  html_url: string
+  contributions: number
+}
+
+async function getContributors(): Promise<GitHubContributor[]> {
+  try {
+    const res = await fetch("https://api.github.com/repos/typst-gost/modern-g7-32/contributors", {
+      next: { revalidate: 3600 },
+      headers: {
+        Accept: "application/vnd.github.v3+json",
+      },
+    })
+
+    if (!res.ok) {
+      console.error("Failed to fetch contributors:", res.statusText)
+      return[]
+    }
+
+    return await res.json()
+  } catch (error) {
+    console.error("Error fetching contributors:", error)
+    return[]
+  }
+}
+
+function TelegramIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm5.894 8.221-1.97 9.28c-.145.658-.537.818-1.084.508l-3-2.21-1.447 1.394c-.16.16-.295.295-.605.295l.213-3.053 5.56-5.023c.242-.213-.054-.333-.373-.12L7.16 13.547l-2.965-.924c-.643-.204-.657-.643.136-.953l11.57-4.461c.537-.194 1.006.131.993.012z" />
+    </svg>
+  )
+}
+
+export default async function AuthorsPage() {
+  const allContributors = await getContributors()
+
+  const authorLogins = authors.map((a) => a.github.split("/").pop()?.toLowerCase())
+
+  const contributors = allContributors.filter(
+    (c) => c.login && !authorLogins.includes(c.login.toLowerCase()) && !c.login.startsWith("dependabot") && !c.login.startsWith("actions-user")
+  )
+
+  return (
+    <div className="min-h-screen flex flex-col relative bg-gray-950">
+      <PageBackground />
+      <div className="relative z-10 flex flex-col flex-1">
+        <Navbar />
+        <main className="container mx-auto px-4 md:px-8 pt-32 pb-16 flex-1 flex flex-col max-w-5xl">
+          <div className="max-w-2xl mb-12">
+            <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 tracking-tight">Об авторах</h1>
+            <p className="text-gray-400 text-lg leading-relaxed">
+              Экосистема <strong className="text-white font-semibold">Typst Gost</strong> и шаблон{" "}
+              <strong className="text-white font-semibold">modern-g7-32</strong> созданы и поддерживаются
+              открытым сообществом разработчиков.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8 items-stretch mb-16">
+            {authors.map((author) => (
+              <div
+                key={author.name}
+                className={cn(
+                  "group relative overflow-hidden rounded-3xl border transition-all duration-300 flex flex-col",
+                  "bg-gray-900/40 backdrop-blur-sm hover:bg-gray-800/60",
+                  author.isInactive ? "border-gray-800/50" : "border-gray-700/50 hover:border-blue-500/30"
+                )}
+              >
+                {author.isInactive && (
+                  <div className="absolute top-7 -right-12 z-20 w-48 rotate-45 border-y border-red-500/20 bg-red-500/10 py-1.5 text-center text-[10px] font-bold uppercase tracking-widest text-red-400 backdrop-blur-md shadow-sm pointer-events-none">
+                    Неактивен
+                  </div>
+                )}
+
+                <div className="relative p-6 sm:p-8 flex flex-col flex-1">
+                  <div className="flex items-start gap-5 mb-5">
+                    <div className="relative w-16 h-16 shrink-0 rounded-2xl overflow-hidden border border-gray-700/50 bg-gray-800/50 flex items-center justify-center">
+                      {author.avatarPath ? (
+                        <Image src={author.avatarPath} alt={author.name} fill className="object-cover" />
+                      ) : (
+                        <User className="w-8 h-8 text-gray-500" />
+                      )}
+                    </div>
+                    <div className="flex-1 pt-1 pr-4">
+                      <h2 className="text-2xl font-bold text-white tracking-tight">{author.name}</h2>
+                      <p className={cn("text-sm font-medium", author.isInactive ? "text-gray-500" : "text-blue-400")}>
+                        {author.role}
+                      </p>
+                    </div>
+                  </div>
+
+                  {author.tags && author.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-8">
+                      {author.tags.map((tag) => (
+                        <span key={tag.label} className={cn("px-2.5 py-1 rounded-full text-[10px] sm:text-xs font-semibold uppercase tracking-wider border", tag.className)}>
+                          {tag.label}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  <div className="flex flex-wrap items-center gap-3 mt-auto relative z-10">
+                    <a href={author.github} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-white/5 text-sm text-gray-300 hover:text-white border border-transparent hover:border-white/10 hover:bg-white/10 transition-all">
+                      <Github className="w-4 h-4" /> 
+                      <span className="font-medium">GitHub</span>
+                      <ExternalLink className="w-3 h-3 opacity-50" />
+                    </a>
+                    {author.telegram && (
+                      <a href={author.telegram} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-[#2AABEE]/10 text-sm text-[#2AABEE] border border-transparent hover:border-[#2AABEE]/30 hover:bg-[#2AABEE]/20 transition-all">
+                        <TelegramIcon className="w-4 h-4" /> 
+                        <span className="font-medium">Telegram</span>
+                        <ExternalLink className="w-3 h-3 opacity-50" />
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {contributors.length > 0 && (
+            <div className="mt-8 border-t border-gray-800/40 pt-12">
+              <div className="flex items-center gap-4 mb-8">
+                <h2 className="text-2xl font-bold text-white tracking-tight">Контрибьюторы</h2>
+                <span className="flex items-center justify-center bg-gray-800 text-gray-300 text-sm font-bold px-3.5 py-1 rounded-full border border-gray-700/50">
+                  {contributors.length}
+                </span>
+              </div>
+
+              <div className="flex flex-wrap gap-3 sm:gap-4">
+                {contributors.map((c) => (
+                  <a
+                    key={c.login}
+                    href={c.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={`${c.login} (${c.contributions} contributions)`}
+                    className="group relative w-12 h-12 sm:w-14 sm:h-14 rounded-full overflow-hidden border-2 border-gray-800 hover:border-gray-500 hover:shadow-[0_0_15px_rgba(255,255,255,0.1)] transition-all duration-300 z-0 hover:z-10 bg-gray-800"
+                  >
+                    <Image
+                      src={c.avatar_url}
+                      alt={c.login}
+                      fill
+                      sizes="56px"
+                      className="object-cover transition-transform duration-300 group-hover:scale-110"
+                    />
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="mt-auto pt-16">
+            <div className="p-6 rounded-2xl bg-gray-900/30 border border-gray-800/50 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+              <p className="text-gray-400 text-sm leading-relaxed max-w-xl">
+                Исходный код шаблона распространяется свободно. Вы можете изучить его, предложить улучшения или использовать в своих проектах на{' '}
+                <a
+                  href={NAVIGATION_LINKS.GITHUB_REPO}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-400 hover:text-blue-300 font-medium transition-colors"
+                >
+                  GitHub
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    </div>
+  )
+}

--- a/src/app/authors/page.tsx
+++ b/src/app/authors/page.tsx
@@ -4,9 +4,10 @@ import { Github, User, ExternalLink } from "lucide-react"
 import { Navbar } from "@/components/sections/navbar"
 import { Footer } from "@/components/sections/footer"
 import { PageBackground } from "@/components/decoration/background"
+import { Button } from "@/components/ui/buttons/button"
 import { NAVIGATION_LINKS } from "@/lib/navigation"
 import { cn } from "@/lib/utils"
-import { authors } from "./data"
+import { EXCLUDED_CONTRIBUTOR_LOGINS, authors } from "./data"
 
 export const metadata: Metadata = {
   title: "Об авторах — Typst Gost",
@@ -54,17 +55,23 @@ export default async function AuthorsPage() {
 
   const authorLogins = authors.map((a) => a.github.split("/").pop()?.toLowerCase())
 
-  const contributors = allContributors.filter(
-    (c) => c.login && !authorLogins.includes(c.login.toLowerCase()) && !c.login.startsWith("dependabot") && !c.login.startsWith("actions-user")
-  )
+  const contributors = allContributors.filter((c) => {
+    const login = c.login?.toLowerCase()
+
+    return (
+      login &&
+      !authorLogins.includes(login) &&
+      !EXCLUDED_CONTRIBUTOR_LOGINS.some((excluded) => login === excluded)
+    )
+  })
 
   return (
     <div className="min-h-screen flex flex-col relative bg-gray-950">
       <PageBackground />
       <div className="relative z-10 flex flex-col flex-1">
         <Navbar />
-        <main className="container mx-auto px-4 md:px-8 pt-32 pb-16 flex-1 flex flex-col max-w-5xl">
-          <div className="max-w-2xl mb-12">
+        <main className="container mx-auto px-4 md:px-8 pt-32 pb-10 flex-1 flex flex-col max-w-7xl">
+          <div className="max-w-4xl mb-12">
             <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 tracking-tight">Об авторах</h1>
             <p className="text-gray-400 text-lg leading-relaxed">
               Экосистема <strong className="text-white font-semibold">Typst Gost</strong> и шаблон{" "}
@@ -73,7 +80,7 @@ export default async function AuthorsPage() {
             </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8 items-stretch mb-16">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-stretch mb-12">
             {authors.map((author) => (
               <div
                 key={author.name}
@@ -136,7 +143,7 @@ export default async function AuthorsPage() {
           </div>
 
           {contributors.length > 0 && (
-            <div className="mt-8 border-t border-gray-800/40 pt-12">
+            <div className="border-t border-gray-800/40 pt-10">
               <div className="flex items-center gap-4 mb-8">
                 <h2 className="text-2xl font-bold text-white tracking-tight">Контрибьюторы</h2>
                 <span className="flex items-center justify-center bg-gray-800 text-gray-300 text-sm font-bold px-3.5 py-1 rounded-full border border-gray-700/50">
@@ -144,30 +151,44 @@ export default async function AuthorsPage() {
                 </span>
               </div>
 
-              <div className="flex flex-wrap gap-3 sm:gap-4">
-                {contributors.map((c) => (
-                  <a
-                    key={c.login}
-                    href={c.html_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title={`${c.login} (${c.contributions} contributions)`}
-                    className="group relative w-12 h-12 sm:w-14 sm:h-14 rounded-full overflow-hidden border-2 border-gray-800 hover:border-gray-500 hover:shadow-[0_0_15px_rgba(255,255,255,0.1)] transition-all duration-300 z-0 hover:z-10 bg-gray-800"
-                  >
-                    <Image
-                      src={c.avatar_url}
-                      alt={c.login}
-                      fill
-                      sizes="56px"
-                      className="object-cover transition-transform duration-300 group-hover:scale-110"
-                    />
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                <Button
+                  asChild
+                  variant="primary"
+                  className="w-fit bg-blue-600/90 hover:bg-blue-500/90 text-white shadow-[0_0_24px_rgba(37,99,235,0.18)]"
+                >
+                  <a href="https://github.com/typst-gost/modern-g7-32" target="_blank" rel="noopener noreferrer">
+                    <Github className="w-4 h-4" />
+                    Стать контрибьютором
+                    <ExternalLink className="w-3 h-3 opacity-60" />
                   </a>
-                ))}
+                </Button>
+
+                <div className="flex flex-wrap gap-3 sm:gap-4">
+                  {contributors.map((c) => (
+                    <a
+                      key={c.login}
+                      href={c.html_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={`${c.login} (${c.contributions} contributions)`}
+                      className="group relative w-12 h-12 sm:w-14 sm:h-14 rounded-full overflow-hidden border-2 border-gray-800 hover:border-gray-500 hover:shadow-[0_0_15px_rgba(255,255,255,0.1)] transition-all duration-300 z-0 hover:z-10 bg-gray-800"
+                    >
+                      <Image
+                        src={c.avatar_url}
+                        alt={c.login}
+                        fill
+                        sizes="56px"
+                        className="object-cover transition-transform duration-300 group-hover:scale-110"
+                      />
+                    </a>
+                  ))}
+                </div>
               </div>
             </div>
           )}
 
-          <div className="mt-auto pt-16">
+          <div className="mt-auto pt-12">
             <div className="p-6 rounded-2xl bg-gray-900/30 border border-gray-800/50 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
               <p className="text-gray-400 text-sm leading-relaxed max-w-xl">
                 Исходный код шаблона распространяется свободно. Вы можете изучить его, предложить улучшения или использовать в своих проектах на{' '}

--- a/src/app/authors/page.tsx
+++ b/src/app/authors/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next"
 import Image from "next/image"
-import { Github, User, ExternalLink } from "lucide-react"
+import { Github, User, ExternalLink, Globe } from "lucide-react" // Добавили Globe
 import { Navbar } from "@/components/sections/navbar"
 import { Footer } from "@/components/sections/footer"
 import { PageBackground } from "@/components/decoration/background"
@@ -32,13 +32,13 @@ async function getContributors(): Promise<GitHubContributor[]> {
 
     if (!res.ok) {
       console.error("Failed to fetch contributors:", res.statusText)
-      return[]
+      return []
     }
 
     return await res.json()
   } catch (error) {
     console.error("Error fetching contributors:", error)
-    return[]
+    return []
   }
 }
 
@@ -71,7 +71,7 @@ export default async function AuthorsPage() {
       <div className="relative z-10 flex flex-col flex-1">
         <Navbar />
         <main className="container mx-auto px-4 md:px-8 pt-32 pb-10 flex-1 flex flex-col max-w-7xl">
-          <div className="max-w-4xl mb-12">
+          <div className="mb-12">
             <h1 className="text-4xl md:text-5xl font-bold text-white mb-6 tracking-tight">Об авторах</h1>
             <p className="text-gray-400 text-lg leading-relaxed">
               Экосистема <strong className="text-white font-semibold">Typst Gost</strong> и шаблон{" "}
@@ -116,7 +116,7 @@ export default async function AuthorsPage() {
                   {author.tags && author.tags.length > 0 && (
                     <div className="flex flex-wrap gap-2 mb-8">
                       {author.tags.map((tag) => (
-                        <span key={tag.label} className={cn("px-2.5 py-1 rounded-full text-[10px] sm:text-xs font-semibold uppercase tracking-wider border", tag.className)}>
+                        <span key={tag.label} className={cn("px-2.5 py-1 rounded-full text-[10px] sm:text-xs font-semibold tracking-wider border", tag.className)}>
                           {tag.label}
                         </span>
                       ))}
@@ -129,10 +129,20 @@ export default async function AuthorsPage() {
                       <span className="font-medium">GitHub</span>
                       <ExternalLink className="w-3 h-3 opacity-50" />
                     </a>
+                    
                     {author.telegram && (
                       <a href={author.telegram} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-[#2AABEE]/10 text-sm text-[#2AABEE] border border-transparent hover:border-[#2AABEE]/30 hover:bg-[#2AABEE]/20 transition-all">
                         <TelegramIcon className="w-4 h-4" /> 
                         <span className="font-medium">Telegram</span>
+                        <ExternalLink className="w-3 h-3 opacity-50" />
+                      </a>
+                    )}
+
+                    {/* Добавлена кнопка для сайта */}
+                    {author.website && (
+                      <a href={author.website} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-emerald-500/10 text-sm text-emerald-400 border border-transparent hover:border-emerald-500/30 hover:bg-emerald-500/20 transition-all">
+                        <Globe className="w-4 h-4" /> 
+                        <span className="font-medium">Сайт</span>
                         <ExternalLink className="w-3 h-3 opacity-50" />
                       </a>
                     )}
@@ -151,19 +161,7 @@ export default async function AuthorsPage() {
                 </span>
               </div>
 
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
-                <Button
-                  asChild
-                  variant="primary"
-                  className="w-fit bg-blue-600/90 hover:bg-blue-500/90 text-white shadow-[0_0_24px_rgba(37,99,235,0.18)]"
-                >
-                  <a href="https://github.com/typst-gost/modern-g7-32" target="_blank" rel="noopener noreferrer">
-                    <Github className="w-4 h-4" />
-                    Стать контрибьютором
-                    <ExternalLink className="w-3 h-3 opacity-60" />
-                  </a>
-                </Button>
-
+              <div className="flex justify-between">
                 <div className="flex flex-wrap gap-3 sm:gap-4">
                   {contributors.map((c) => (
                     <a
@@ -184,6 +182,16 @@ export default async function AuthorsPage() {
                     </a>
                   ))}
                 </div>
+                <Button
+                  asChild
+                  variant="outline"
+                >
+                  <a href="https://github.com/typst-gost/modern-g7-32" target="_blank" rel="noopener noreferrer">
+                    <Github className="w-4 h-4" />
+                    Стать контрибьютором
+                    <ExternalLink className="w-3 h-3 opacity-60" />
+                  </a>
+                </Button>
               </div>
             </div>
           )}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -54,26 +54,30 @@ export default function RootLayout({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              "@context": "https://schema.org",
-              "@type": "SoftwareApplication",
-              name: "Typst Gost",
-              description: "Шаблон для автоматического оформления документов по ГОСТ 7.32-2017",
-              url: siteUrl,
-              applicationCategory: "DeveloperApplication",
-              offers: {
-                "@type": "Offer",
-                price: "0",
-                priceCurrency: "RUB"
-              },
-              potentialAction: {
-                "@type": "UseAction",
-                target: {
-                  "@type": "EntryPoint",
-                  urlTemplate: siteUrl
+            __html: JSON.stringify([
+              {
+                "@context": "https://schema.org",
+                "@type": "WebSite",
+                url: siteUrl,
+                name: "Typst Gost",
+                description: "Шаблон для автоматического оформления документов по ГОСТ 7.32-2017",
+                potentialAction: {
+                  "@type": "SearchAction",
+                  target: `${siteUrl}/docs?q={search_term_string}`,
+                  "query-input": "required name=search_term_string"
                 }
+              },
+              {
+                "@context": "https://schema.org",
+                "@type": "Organization",
+                name: "Typst Gost",
+                url: siteUrl,
+                sameAs: [
+                  "https://github.com/typst-gost",
+                  "https://t.me/typst_gost"
+                ]
               }
-            })
+            ])
           }}
         />
       </head>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,8 @@
+import { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: 'https://typst-gost.ru/sitemap.xml',
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,12 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const siteUrl = 'https://typst-gost.ru'
+  const now = new Date()
+  return [
+    { url: siteUrl, lastModified: now, changeFrequency: 'weekly', priority: 1.0 },
+    { url: `${siteUrl}/docs`, lastModified: now, changeFrequency: 'weekly', priority: 0.9 },
+    { url: `${siteUrl}/examples`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${siteUrl}/authors`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+  ]
+}

--- a/src/components/sections/footer.tsx
+++ b/src/components/sections/footer.tsx
@@ -8,6 +8,7 @@ import { NAVIGATION_LINKS } from "@/lib/navigation"
 const footerLinks = [
   { label: "Документация", href: NAVIGATION_LINKS.DOCS, disabled: true },
   { label: "Примеры", href: NAVIGATION_LINKS.GITHUB_EXAMPLES_REPO, disabled: true, external: true },
+  { label: "Об авторах", href: NAVIGATION_LINKS.ABOUT },
 ]
 
 export function Footer() {

--- a/src/components/sections/navbar.tsx
+++ b/src/components/sections/navbar.tsx
@@ -13,6 +13,7 @@ import { NAVIGATION_LINKS } from "@/lib/navigation"
 const NAV_LINKS = [
   { href: NAVIGATION_LINKS.DOCS, label: "Документация (в работе)", disabled: true },
   { href: NAVIGATION_LINKS.EXAMPLES_INTERNAL, label: "Примеры (в работе)", disabled: true },
+  { href: NAVIGATION_LINKS.ABOUT, label: "Об авторах" },
 ]
 
 export function Navbar() {

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -3,6 +3,7 @@ export const NAVIGATION_LINKS = {
   HOME: "/",
   DOCS: "/docs",
   EXAMPLES_INTERNAL: "/examples",
+  ABOUT: "/authors",
 
   // Внешние ссылки
   TYPST_APP: "https://typst.app",


### PR DESCRIPTION
## Что изменилось
- `src/app/sitemap.ts` — автогенерация `/sitemap.xml` с `/`, `/docs`, `/examples`, `/about` с приоритетами 0.8–1.0
- `src/app/robots.ts` — разрешить всем краулерам, ссылка на sitemap
- `src/app/layout.tsx` — JSON-LD заменён: SoftwareApplication → WebSite + SearchAction + Organization с sameAs
- `src/app/authors/page.tsx` — новая страница `/authors` с карточками авторов (F0rgenet, benzlokzik) и BreadcrumbList JSON-LD
- `src/lib/navigation.ts` — добавлен `ABOUT: "/about"`
- `src/components/sections/navbar.tsx` — добавлена ссылка «Об авторах»
- `src/components/sections/footer.tsx` — добавлена ссылка «Об авторах»

## Проверка
- [ ] `/sitemap.xml` возвращает XML с 4 URL-адресами
- [ ] `/robots.txt` разрешает всё и содержит ссылку на sitemap
- [ ] Страница `/authors` загружается с карточками авторов
- [ ] «Об авторах» видно в навбаре и футере
- [ ] JSON-LD на главной валиден (WebSite + Organization)
- [ ] `bun run build` проходит

Closes #50