### PR TITLE
style(landing): удалить неиспользуемые импорты, нормализовать отступы секций (P1.3)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,11 @@
 import { Navbar } from "@/components/sections/navbar";
 import HeroSection from "@/components/sections/hero/section";
 import PreviewSection from "@/components/sections/preview/section";
-import FeaturesSection from "@/components/sections/features";
 import UsageSection from "@/components/sections/usage/section";
 import { ComparisonSection } from "@/components/sections/comparison/section";
 import { Footer } from "@/components/sections/footer";
 import { PageBackground } from "@/components/decoration/background";
 import FaqSection from "@/components/sections/faq/section";
-import { Section } from "@/components/ui/section";
 import BentoFeaturesSection from "@/components/sections/bento-features/section";
 
 export default function Home() {
@@ -22,9 +20,6 @@ export default function Home() {
         <BentoFeaturesSection />
         <ComparisonSection />
         <UsageSection />
-        {/* <Docs Section /> с <Telegram Section /> */}
-        {/* <FeaturesSection /> TODO: Выпилить */}
-        {/* <CommunitySection /> TODO: Добавить */}
         <FaqSection />
         <Footer />
       </div>

--- a/src/components/sections/bento-features/section.tsx
+++ b/src/components/sections/bento-features/section.tsx
@@ -105,7 +105,7 @@ const Mockups: Record<string, React.FC> = {
 
 export default async function BentoFeaturesSection() {
   return (
-    <section className="py-16 px-4 overflow-hidden">
+    <section className="py-8 md:py-16 px-4 overflow-hidden">
       <div className="container mx-auto max-w-7xl">
         <Heading
           title="Простота использования"


### PR DESCRIPTION
## Что изменилось
- `src/app/page.tsx`: удалены неиспользуемые импорты `Section` и `FeaturesSection`; удалены закомментированные заглушки (`TODO: Выпилить`, `TODO: Добавить`)
- `src/components/sections/bento-features/section.tsx`: `py-16` → `py-8 md:py-16` для соответствия адаптивному паттерну отступов соседних секций

## Проверка
- [ ] `bun run build` проходит без предупреждений об неиспользуемых импортах
- [ ] Лендинг корректно отображает все секции
- [ ] Верхний отступ секции Bento выглядит согласованно с соседними секциями на мобильном

Closes #52